### PR TITLE
resolve issues with out of sync thread pool counters

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -87,8 +87,11 @@ module Puma
 
               @waiting += 1
               not_full.signal
-              not_empty.wait mutex
-              @waiting -= 1
+              begin
+                not_empty.wait mutex
+              ensure
+                @waiting -= 1
+              end
             end
 
             work = todo.shift if continue

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -171,6 +171,16 @@ module Puma
         end
 
         @workers -= dead_workers
+
+        (@todo.size - @spawned).times do
+          if @waiting < @todo.size and @spawned < @max
+            spawn_thread
+          else
+            break
+          end
+        end
+
+        @not_empty.signal
       end
     end
 

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -168,17 +168,14 @@ module Puma
         dead_workers.each do |worker|
           worker.kill
           @spawned -= 1
+          # if there's work waiting for a usable thread and we now have available slots in our
+          # pool, spawn a thread to process that outstanding work
+          if @waiting < @todo.size and @spawned < @max
+            spawn_thread
+          end
         end
 
         @workers -= dead_workers
-
-        (@todo.size - @spawned).times do
-          if @waiting < @todo.size and @spawned < @max
-            spawn_thread
-          else
-            break
-          end
-        end
 
         @not_empty.signal
       end

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -240,4 +240,25 @@ class TestThreadPool < Test::Unit::TestCase
 
     assert_equal 0, pool.backlog
   end
+
+  def test_correct_waiting_count_for_killed_threads
+    pool = new_pool(1, 1) { |_| }
+
+    pause
+
+    # simulate our waiting worker thread getting killed for whatever reason
+    pool.instance_eval { @workers[0].kill }
+
+    pause
+
+    pool.reap
+
+    pause
+
+    pool << 0
+
+    pause
+
+    assert_equal 0, pool.backlog
+  end
 end

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -262,3 +262,4 @@ class TestThreadPool < Test::Unit::TestCase
     assert_equal 0, pool.backlog
   end
 end
+

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -226,4 +226,18 @@ class TestThreadPool < Test::Unit::TestCase
 
     assert_equal 0, pool.spawned
   end
+
+  def test_reap_processes_remaining_work
+    pool = new_pool(0,1) { |work| work == 0 ? Thread.current.kill : nil }
+
+    2.times { |i| pool << i }
+
+    pause
+
+    pool.reap
+
+    pause
+
+    assert_equal 0, pool.backlog
+  end
 end


### PR DESCRIPTION
- If there is more work in the todo queue than threads available in the pool to process the work, but somehow the threads are no longer alive, the reaper appropriately comes along and reaps them.  However, if there are remaining work items to do, they are not scheduled to be run, but sit there not being processed.  They are only scheduled to be processed when a new item is pushed into the queue.
 - if a thread is in the wait state, but transitions into a killed state the '@waiting' counter will not be decremented leaving the pool to believe there is a thread available and waiting to complete work when that is not the case. Introduce a begin..ensure block so that any thread exception raised while in the wait state properly balances the '@waiting' counter.