### PR TITLE
continue processing work after reaping

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -168,9 +168,17 @@ module Puma
         dead_workers.each do |worker|
           worker.kill
           @spawned -= 1
+
+          # if there's work waiting for a usable thread and we now have available slots in our
+          # pool, spawn a thread to process that outstanding work
+          if @waiting < @todo.size and @spawned < @max
+            spawn_thread
+          end
         end
 
         @workers -= dead_workers
+
+        @not_empty.signal
       end
     end
 

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -226,4 +226,18 @@ class TestThreadPool < Test::Unit::TestCase
 
     assert_equal 0, pool.spawned
   end
+
+  def test_reap_processes_remaining_work
+    pool = new_pool(0,1) { |work| work == 0 ? Thread.current.kill : nil }
+
+    2.times { |i| pool << i }
+
+    pause
+
+    pool.reap
+
+    pause
+
+    assert_equal 0, pool.backlog
+  end
 end


### PR DESCRIPTION
If there is more work in the todo queue than threads available in the pool to process the work, but somehow the threads are no longer alive, the reaper appropriately comes along and reaps them.  However, if there are remaining work items to do, they are not scheduled to be run, but sit there not being processed.  They are only scheduled to be processed when a new item is pushed into the queue.