### PR TITLE
resolve waiting counter problem

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -87,8 +87,11 @@ module Puma
 
               @waiting += 1
               not_full.signal
-              not_empty.wait mutex
-              @waiting -= 1
+              begin
+                not_empty.wait mutex
+              ensure
+                @waiting -= 1
+              end
             end
 
             work = todo.shift if continue

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -240,4 +240,24 @@ class TestThreadPool < Test::Unit::TestCase
 
     assert_equal 0, pool.backlog
   end
+
+  def test_correct_waiting_count_for_killed_threads
+    pool = new_pool(1, 1) { |_| }
+
+    pause
+
+    # simulate our waiting worker thread getting killed for whatever reason
+    pool.instance_eval { @workers[0].kill }
+
+    pause
+
+    pool.reap
+
+    pause
+
+    pool << 0
+
+    pause
+    assert_equal 0, pool.backlog
+  end
 end


### PR DESCRIPTION
if a thread is in the wait state, but transitions into a killed state the waiting counter will not be decremented leaving the pool to believe there is a thread available and waiting to complete work when that is not the case. Introduce a begin..ensure block so that any thread exception raised while in the wait state properly balances the waiting counter.