### PR TITLE
fix infinite loop

### DIFF
--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -264,6 +264,8 @@ public class MiniSSL extends RubyObject {
             if (res.getStatus() == Status.BUFFER_UNDERFLOW) {
               // need more data before we can shake more hands
               done = true;
+            } else if (res.getStatus() == Status.CLOSED) {
+              throw new SSLException("Detected socket CLOSED during NEED_UNWRAP");
             }
             break;
           default:


### PR DESCRIPTION
If the ssl engine result status changes to CLOSED during a NEED_UNWRAP handshake operation, an infinite loop ensues as 'done' is always true. We now raise an exception for the outer exception handler to deal with and termine the read operation as expected.

This was causing the Puma tests to hang when run under JRuby.