### PR TITLE
add missing init? and shutdown methods

### DIFF
--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -343,4 +343,27 @@ public class MiniSSL extends RubyObject {
       return getRuntime().getNil();
     }
   }
+
+  @JRubyMethod(name = "init?")
+  public IRubyObject sslInitializing() {
+    Boolean isHandshaking = engine.getHandshakeStatus() != HandshakeStatus.NOT_HANDSHAKING;
+
+    return isHandshaking ? getRuntime().getTrue() : getRuntime().getFalse();
+  }
+
+  @JRubyMethod(name = "shutdown")
+  public IRubyObject sslShutdown() {
+    engine.closeOutbound();
+
+    try {
+      engine.closeInbound();
+    } catch(SSLException e) {
+      // thrown if this engine has not received the proper SSL/TLS close notification message from the peer.
+      // ignore this here as we only care if it returns successfully.
+    }
+
+    Boolean allClosed = engine.isInboundDone() && engine.isOutboundDone();
+
+    return allClosed ? getRuntime().getTrue() : getRuntime().getFalse();
+  }
 }


### PR DESCRIPTION
Puma adjusted their SSL support for MRI Ruby, but it appears as if they did not keep the JRuby version up to date.  Here is the offending commit: https://github.com/puma/puma/commit/46416cb49ed2f16614f019cee969bb8f5d0a6146. Note that it adds 2 methods.  'init?' and 'shutdown'. We add the same methods for the JRuby SSL implementation to keep parity with the MRI Ruby implementation.

Both Looker and the Puma tests were throwing errors due to the missing methods which were expected to be implemented.